### PR TITLE
Devx 614 change api

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,22 @@
+version: 2.1
+
+orbs:
+    change-api: financial-times/change-api@0
+
+jobs:
+  build:
+    docker:
+      - image: circleci/node:10
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "package.json" }}
+            - v1-dependencies-
+
+      - run: npm install
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-{{ checksum "package.json" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,3 +20,18 @@ jobs:
           paths:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}
+workflows:
+  version: 2
+  
+  build_and_test:
+    jobs:
+      - build
+      - change-api/release-log:
+          filters:
+            branches:
+              only:
+                - main
+          changeApiKey: '${CHANGE_API_KEY}'
+          systemCode: 'tps-lookup'
+          environment: 'prod'
+          slackChannels: 'ft-changes,ip-devx'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ workflows:
           filters:
             branches:
               only:
-                - main
+                - master
           changeApiKey: '${CHANGE_API_KEY}'
           systemCode: 'tps-lookup'
           environment: 'prod'


### PR DESCRIPTION
Why? OR The Problem
This task is to improve the operability and reliability of IP systems. By adding change api to at least 10% of IP systems. Ticket: https://financialtimes.atlassian.net/browse/DEVX-614

Why were these changes necessary? What problem are you trying to solve? Link to JIRA ticket ?

Over 100 systems in IP currently don't send their change logs to https://changes.in.ft.com/, so to improve our operability and reliability, a change api log is added to this project so whenever theres a change to Main, it will send the log to https://changes.in.ft.com/

What has changed? OR The Solution
App set-up in Circleci

How did you solve the problem?
Be specific, describe your thought process and state the 'obvious' – things are almost never obvious...so be descriptive.

Created an API key for the system, added the system code and also the slack channels to send the change logs to. Ip-devx and ft-changes

## Before & After Screenshots
**AFTER**: [insert screenshot here]

Expecting all merges to Master to send a notification like the below: 

<img width="350" alt="Screenshot 2021-06-30 at 12 05 15" src="https://user-images.githubusercontent.com/53172555/123952335-cac60500-d99d-11eb-9803-a081d5cc7e9f.png">