### PR TITLE
Bower migration

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,35 +2,50 @@
 <html lang="en">
 
   <head>
-    <link rel="stylesheet" href="https://www.ft.com/__origami/service/build/v2/bundles/css?modules=o-buttons@^5.0.2,o-techdocs@^7.0.2,o-forms@^4.0.1,o-icons@^5.4.0,o-grid@^4.3.3" />
+    <link rel="stylesheet" href="https://www.ft.com/__origami/service/build/v2/bundles/css?modules=o-buttons@^6.0.0,o-forms@^8.0.0,o-icons@^6.0.0,o-grid@^5.0.0,o-layout@^4.5.0,o-header-services@^4.0.15&brand=internal" />
     <link rel="stylesheet" type="text/css" href="/main.css">
     <meta charset="UTF-8">
     <title>TPS Screener</title>
   </head>
 
   <body class="search-body">
-    <header data-o-component="o-header" class="o-header-services">
-      <div class="o-header-services__top o-header-services__container">
-        <div class="o-header-services__ftlogo"></div>
-        <div class="o-header-services__title">
-          <h1 class="o-header-services__product-name">Internal Products - TPS Screener</h1>
-        </div>
-        <div class="o-header-services__related-content">
-          <a class="o-header-services__related-content-link logout-link" href="#">Logout</a>
-          <form class="logout-form" method="post" action="/logout">
-          </form>
-        </div>
+    <!-- <div class="o-layout o-layout--docs" data-o-component="o-layout"> -->
+      <div class="o-layout__header">
+        <header class="o-header-services" data-o-component="o-header-services">
+          <div class="o-header-services__top">
+            <div class="o-header-services__logo"></div>
+            <div class="o-header-services__title">
+              <span class="o-header-services__product-name">Internal Products - TPS Screener</span>
+            </div>
+            <div class="o-header-services__related-content">
+              <a class="o-header-services__related-content-link logout-link" href="#">Logout</a>
+              <form class="logout-form" method="post" action="/logout">
+              </form>
+            </div>
+          </div>
+        </header>
       </div>
-    </header>
-    <div class="o-techdocs-container">
-      <div class="o-techdocs-layout">
-        <div class="o-techdocs-main">
+    <!-- </div> -->
+    <!-- <div class="o-techdocs-container"> -->
+      <!-- <div class="o-techdocs-layout"> -->
+        <div class="o-layout-main">
           <!--<section class="o-techdocs-content about">-->
           <div class="o-grid-container">
             <div class="o-grid-row">
-              <div data-o-grid-colspan="7">
+              <div data-o-grid-colspan="6">
                 <form class="search-form">
-                  <div class="o-forms">
+                  <label class="o-forms-field">
+                    <span class="o-forms-title">
+                      <span class="o-forms-title__main">Phone Number</span>
+                    </span>
+                  
+                    <span class="o-forms-input o-forms-input--text o-forms-input--suffix">
+                      <input type="text" id="search-input" class="o-forms__text search-input" placeholder="UK Phone number" required pattern="^0(?!044)[\d ]+$" />
+                  
+                      <button class="o-buttons o-buttons--secondary o-buttons--big">Search</button>
+                    </span>
+                  </label>
+                  <!-- <div class="o-forms">
                     <label for="search-input" class="o-forms__label">Phone Number</label>
                     <div class="o-forms__affix-wrapper">
                       <input type="text" id="search-input" class="o-forms__text search-input" placeholder="UK Phone number" required pattern="^0(?!044)[\d ]+$"/>
@@ -38,7 +53,7 @@
                         <button type="submit" class="search-button o-buttons">Search</button>
                       </div>
                     </div>
-                  </div>
+                  </div> -->
                 </form>
               </div>
               <div data-o-grid-colspan="4">
@@ -57,9 +72,9 @@
             </div>
           </div>
         </div>
-      </div>
+      <!-- </div> -->
         <!--</section>-->
-    </div>
+    <!-- </div> -->
     <script src="/bundle.js"></script>
   </body>
 

--- a/index.html
+++ b/index.html
@@ -2,14 +2,14 @@
 <html lang="en">
 
   <head>
-    <link rel="stylesheet" href="https://www.ft.com/__origami/service/build/v2/bundles/css?modules=o-buttons@^6.0.0,o-forms@^8.0.0,o-icons@^6.0.0,o-grid@^5.0.0,o-layout@^4.5.0,o-header-services@^4.0.15&brand=internal" />
+    <link rel="stylesheet" href="https://www.ft.com/__origami/service/build/v3/bundles/css?components=o-buttons@^7.5.0,o-forms@^9.2.4,o-icons@^7.2.1,o-grid@^6.1.5,o-layout@^5.2.2,o-header-services@^5.2.2,o-autoinit@^3.1.1&brand=internal&system_code=ft-tps-screener" />
     <link rel="stylesheet" type="text/css" href="/main.css">
     <meta charset="UTF-8">
     <title>TPS Screener</title>
   </head>
 
   <body class="search-body">
-    <!-- <div class="o-layout o-layout--docs" data-o-component="o-layout"> -->
+    <div class="o-layout o-layout--landing" data-o-component="o-layout">
       <div class="o-layout__header">
         <header class="o-header-services" data-o-component="o-header-services">
           <div class="o-header-services__top">
@@ -25,57 +25,37 @@
           </div>
         </header>
       </div>
-    <!-- </div> -->
-    <!-- <div class="o-techdocs-container"> -->
-      <!-- <div class="o-techdocs-layout"> -->
-        <div class="o-layout-main">
-          <!--<section class="o-techdocs-content about">-->
-          <div class="o-grid-container">
-            <div class="o-grid-row">
-              <div data-o-grid-colspan="6">
-                <form class="search-form">
-                  <label class="o-forms-field">
-                    <span class="o-forms-title">
-                      <span class="o-forms-title__main">Phone Number</span>
-                    </span>
-                  
-                    <span class="o-forms-input o-forms-input--text o-forms-input--suffix">
-                      <input type="text" id="search-input" class="o-forms__text search-input" placeholder="UK Phone number" required pattern="^0(?!044)[\d ]+$" />
-                  
-                      <button class="o-buttons o-buttons--secondary o-buttons--big">Search</button>
-                    </span>
-                  </label>
-                  <!-- <div class="o-forms">
-                    <label for="search-input" class="o-forms__label">Phone Number</label>
-                    <div class="o-forms__affix-wrapper">
-                      <input type="text" id="search-input" class="o-forms__text search-input" placeholder="UK Phone number" required pattern="^0(?!044)[\d ]+$"/>
-                      <div class="o-forms__suffix">
-                        <button type="submit" class="search-button o-buttons">Search</button>
-                      </div>
-                    </div>
-                  </div> -->
-                </form>
-              </div>
-              <div data-o-grid-colspan="4">
-                Number must begin with a 0 and not include the country code.<br>
-                <strong>Example</strong>: 077xxxxxxxx
-              </div>
-            </div>
-            <div class="o-grid-row">
-              <div data-o-grid-colspan="12">
-                <div class="search-result">
-                  <span class="search-result-text"></span>
-                  <img id="img-cross" class="img-hidden" src="https://www.ft.com/__origami/service/image/v2/images/raw/fticon-v1:cross?source=o-icons&tint=ff0000">
-                  <img id="img-tick" class="img-hidden" src="https://www.ft.com/__origami/service/image/v2/images/raw/fticon-v1:tick?source=o-icons&tint=4BB543">
-                </div>
-              </div>
+      <div class="o-layout__main o-layout-typography" data-o-component="o-syntax-highlight">
+        <div class="o-grid-container">
+          <div data-o-grid-colspan="5">
+            <form class="search-form">
+              <label class="o-forms-field">
+                <span class="o-forms-title">
+                  <span class="o-forms-title__main">Phone Number</span>
+                </span>
+                <span class="o-forms-input o-forms-input--text o-forms-input--suffix">
+                  <input type="text" id="search-input" class="o-forms__text search-input" placeholder="UK Phone number" required pattern="^0(?!044)[\d ]+$" />
+                  <button class="o-buttons o-buttons--secondary o-buttons--big">Search</button>
+                </span>
+              </label>
+            </form>
+          </div>
+          <div data-o-grid-colspan="4">
+            Number must begin with a 0 and not include the country code.<br>
+            <strong>Example</strong>: 077xxxxxxxx
+          </div>
+        </div>
+        <div class="o-grid-row">
+          <div data-o-grid-colspan="12">
+            <div class="search-result">
+              <span class="search-result-text"></span>
+              <img id="img-cross" class="img-hidden" src="https://www.ft.com/__origami/service/image/v2/images/raw/fticon-v1:cross?source=o-icons&tint=ff0000">
+              <img id="img-tick" class="img-hidden" src="https://www.ft.com/__origami/service/image/v2/images/raw/fticon-v1:tick?source=o-icons&tint=4BB543">
             </div>
           </div>
         </div>
-      <!-- </div> -->
-        <!--</section>-->
-    <!-- </div> -->
+      </div>
+    </div>
     <script src="/bundle.js"></script>
   </body>
-
 </html>

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -30,7 +30,7 @@ function searchHandler(e) {
     body: JSON.stringify([numberInput.value])
   }
 
-  fetch('http://localhost:3000/search', options)
+  fetch('https://tps-screener.ft.com/search', options)
     .then(res => {
       return res.json();
     })

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -30,7 +30,7 @@ function searchHandler(e) {
     body: JSON.stringify([numberInput.value])
   }
 
-  fetch('https://tps-screener.ft.com/search', options)
+  fetch('http://localhost:3000/search', options)
     .then(res => {
       return res.json();
     })


### PR DESCRIPTION
## Why? OR The Problem

[Jira Ticket](https://financialtimes.atlassian.net/jira/software/c/projects/CRME/boards/1257?modal=detail&selectedIssue=CRME-1173&assignee=5d8d0e18c26b6a0dcb0cfe3a) Bower is going to be deprecated so we have to migrate to origami v3 build service.

## What has changed? OR The Solution
I have added the new updated build service url to the index.html. As this app origami components hasn't been updated for a while, I have updated each component to origami latest version of v2 build service and then used the url updater provided by origami to update to origami v3 build service.

## Before & After Screenshots

**BEFORE**: 
![tpsOriginal](https://user-images.githubusercontent.com/37800129/159015915-0402ab9c-bc30-489e-8b82-10de1d9c3af2.png)

**AFTER**: 
![v3-build](https://user-images.githubusercontent.com/37800129/159015818-3de00ad0-dbf6-4ff3-bb16-609733e576bc.png)
