### PR TITLE
 Updated express package suggested by snyk from 4.17.1 to 4.19.2

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -205,6 +205,26 @@ ignore:
         reason: None Given
         expires: 2022-12-01T13:50:41.400Z
         created: 2022-11-01T13:50:41.411Z
+  SNYK-JS-AXIOS-6124857:
+    - '*':
+        reason: None Given
+        expires: 2024-06-27T13:22:04.298Z
+        created: 2024-05-28T13:22:04.306Z
+  SNYK-JS-XML2JS-5414874:
+    - '*':
+        reason: None Given
+        expires: 2024-06-27T13:23:41.800Z
+        created: 2024-05-28T13:23:41.811Z
+  SNYK-JS-INFLIGHT-6095116:
+    - '*':
+        reason: None Given
+        expires: 2024-06-27T13:24:55.576Z
+        created: 2024-05-28T13:24:55.588Z
+  SNYK-JS-AXIOS-6032459:
+    - '*':
+        reason: None Given
+        expires: 2024-06-27T13:25:28.905Z
+        created: 2024-05-28T13:25:28.918Z
 # patches apply the minimum changes required to fix a vulnerability
 patch:
   SNYK-JS-LODASH-567746:

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "dynamo-backup-to-s3": "^0.6.1",
         "eslint-plugin-jest": "^23.20.0",
         "event-stream": "^3.3.4",
-        "express": "^4.17.1",
+        "express": "^4.19.2 ",
         "form-data": "^2.5.1",
         "sass": "^1.49.9",
         "semver": "^6.3.1",
@@ -2509,12 +2509,12 @@
       "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
     },
     "node_modules/body-parser": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
-      "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
+      "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
       "dependencies": {
         "bytes": "3.1.2",
-        "content-type": "~1.0.4",
+        "content-type": "~1.0.5",
         "debug": "2.6.9",
         "depd": "2.0.0",
         "destroy": "1.2.0",
@@ -2522,7 +2522,7 @@
         "iconv-lite": "0.4.24",
         "on-finished": "2.4.1",
         "qs": "6.11.0",
-        "raw-body": "2.5.1",
+        "raw-body": "2.5.2",
         "type-is": "~1.6.18",
         "unpipe": "1.0.0"
       },
@@ -3327,9 +3327,9 @@
       }
     },
     "node_modules/content-type": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -4906,16 +4906,16 @@
       }
     },
     "node_modules/express": {
-      "version": "4.18.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
-      "integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
+      "version": "4.19.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
+      "integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.1",
+        "body-parser": "1.20.2",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.5.0",
+        "cookie": "0.6.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -4947,9 +4947,9 @@
       }
     },
     "node_modules/express/node_modules/cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -8982,9 +8982,9 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
-      "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
       "dependencies": {
         "bytes": "3.1.2",
         "http-errors": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "dynamo-backup-to-s3": "^0.6.1",
     "eslint-plugin-jest": "^23.20.0",
     "event-stream": "^3.3.4",
-    "express": "^4.17.1",
+    "express": "^4.19.2 ",
     "form-data": "^2.5.1",
     "sass": "^1.49.9",
     "semver": "^6.3.1",


### PR DESCRIPTION
## Why? OR The Problem
In order to keep the application safe and with the version required by Snyk. I have upgraded the above pkg.
I have also ignore the package that could break in production as the major and patch version suggested is beyond the accepted version on this legacy app. I have test this app with the npm run test command which triggers snyk. The dependency is no longer displayed under the list of Vulnerabilities requiring update.

Why were these changes necessary? What problem are you trying to solve? Link to JIRA ticket ?
https://financialtimes.atlassian.net/browse/CRM-3404

## Test it locally:
Copy the branch - update-express-pkg-snyk-vulnerability

On the package.json replace the start and dev commands with the following:
`"start": "doppler run -p ft-tps-screener -c prod -- node app.js",`
`"start:dev": "doppler run -p ft-tps-screener -c dev-- node app.js",`

Loggin into Doppler with the following command:
`Doppler login ` and follow the instructions to be authenticated.

Run the below command:
` npm run postinstall     `

When prompted go to the localhost:3000 in the browser. It will ask you to enter a 11 digit telephone number it will only work if the number you entered is not registered with TPS which means the number can be called for sales and market purposes.
## After changes localhost:3000 still works
![Screenshot 2024-05-28 at 16 14 43](https://github.com/Financial-Times/tps-lookup/assets/32463353/469aff30-cd5f-4a8f-836e-2a6904481746)


## What has changed? OR The Solution
 express package from 4.17.1 to 4.19.2
How did you solve the problem?
Be specific, describe your thought process and state the 'obvious' – things are almost never obvious...so be descriptive.

## Before & After Screenshots
lodash version for this application v 3.10.1 under patchable issues - snyk is suggesting an upgrade of v 4.17.5 which could cause a potential breakage in production. 
![Screenshot 2024-05-28 at 14 39 43](https://github.com/Financial-Times/tps-lookup/assets/32463353/628e376e-b9f0-4c9f-8a19-6329a4f8db8a)




 

