### PR TITLE
Snyk test all okay-replaced start command-updated readme

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -44,12 +44,16 @@ ignore:
         expires: '2020-07-09T12:11:16.127Z'
     - '*':
         reason: None Given
-        expires: 2022-12-01T13:49:59.517Z
-        created: 2022-11-01T13:49:59.527Z
+        expires: 2024-07-11T10:50:52.438Z
+        created: 2024-06-11T10:50:52.447Z
   'npm:lodash:20180130':
     - s3o-middleware > node-rsa > lodash:
         reason: no fix available
         expires: '2020-07-09T12:11:16.127Z'
+    - '*':
+        reason: None Given
+        expires: 2024-07-11T10:59:27.835Z
+        created: 2024-06-11T10:59:27.849Z
   SNYK-JS-MINIMIST-559764:
     - browserify > subarg > minimist:
         reason: no fix available
@@ -138,8 +142,8 @@ ignore:
         expires: '2022-04-13T11:19:29.050Z'
     - '*':
         reason: None Given
-        expires: 2022-12-01T13:45:59.034Z
-        created: 2022-11-01T13:45:59.044Z
+        expires: 2024-07-11T10:49:37.018Z
+        created: 2024-06-11T10:49:37.029Z
   SNYK-JS-LODASH-1040724:
     - dynamo-backup-to-s3 > lodash:
         reason: None given
@@ -225,6 +229,16 @@ ignore:
         reason: None Given
         expires: 2024-06-27T13:25:28.905Z
         created: 2024-05-28T13:25:28.918Z
+  SNYK-JS-REQUEST-3361831:
+    - '*':
+        reason: None Given
+        expires: 2024-07-11T10:49:11.929Z
+        created: 2024-06-11T10:49:11.944Z
+  SNYK-20180130:
+    - '*':
+        reason: None Given
+        expires: 2024-07-11T10:51:35.013Z
+        created: 2024-06-11T10:51:35.026Z
 # patches apply the minimum changes required to fix a vulnerability
 patch:
   SNYK-JS-LODASH-567746:

--- a/README.md
+++ b/README.md
@@ -12,32 +12,23 @@ Then, an FT service can internally query the TPS Screener to filter the list of 
 
 ## Usage
 
-**Setting up**
+**Setting up/App run**
 
-1. Navigate to the project where you have cloned this to the machine.
-Run this command to install the packages needed for the app locally ( if it is the first time running this project locally)
-
-```shell
-npm run postinstall
+- Node ^18.x.x
+- [Doppler](https://github.com/Financial-Times/ip-ftlive-api#doppler---secrets-management): If new to Doppler, please follow the instruction to install the [CLI](https://docs.doppler.com/docs/install-cli).
 ```
+**To spin up the local instance of the app, run the commands below:**
 
-2. If you haven't already, set up your Vault environment variables using this guide [Vault Wiki](https://github.com/Financial-Times/vault/wiki/Getting-Started-With-Vault), and log into the Internal Products' Vault with `vault login --method=github`. 
+Replace the start command with "start": "doppler run -p ft-tps-screener -c prod -- node app.js" in package.json.
+**_Note: Ensure the start command is reverted to its original state before merge into prod._**
+Run `doppler login` command
+Run `npm run postinstall ` command
+Run `npm run start` command
+Enter a UK number in the browser's search bar; if it's registered, it's important to refrain from contacting for sales and marketing purposes.
 
-3. Run the following command to populate your `.env` file:
+** Snyk Tests**
 
-```shell
-npm run vault:env
-```
-
-4. To spin up the local instance of the app, run the command below:
-
-```shell
-npm start
-```
-
-**Tests**
-
-Run the command `npm run test` for tests.  
+Run`npm run test` command
 - This will run a `snyk test` as specified in the `scripts` in `package.json`  
 - No other testing is configured for now.
 

--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
     "test": "snyk test",
     "compileAll": "./bin/main.sh compileAll",
     "postinstall": "npm run compileAll",
-    "start": "node app.js",
+    "start": "doppler run -p ft-tps-screener -c prod -- node app.js",
     "prepare": "npm run snyk-protect; npm run snyk-protect",
     "snyk-protect": "snyk-protect",
-    "vault:env": "vault read --format json /secret/teams/internal-products/ft-tps-screener/development | jq -r \".data|to_entries|map(\\\"\\(.key)='\\(.value|tostring)'\\\")|.[]\" > .env"
+    "start:dev": "doppler run -p ft-tps-screener -c dev -- node app.js"
   },
   "author": "Andrew Snead",
   "license": "ISC",


### PR DESCRIPTION
## Changes

Updated the readme with instruction to run the app locally.

I have test this app with the npm run test command which triggers snyk. The dependency is no longer displayed under the list of Vulnerabilities requiring update.

Why were these changes necessary? What problem are you trying to solve? Link to JIRA ticket ?
https://financialtimes.atlassian.net/browse/CRM-3404

## Test it locally:
copy this branch 
Replace the start command with "start": "doppler run -p ft-tps-screener -c prod -- node app.js" in package.json.
**_Note: Ensure the start command is reverted to its original state before merge into prod._**
Run `doppler login` command
Run `npm run postinstall ` command
Run `npm run start` command
Enter a UK number in the browser's search bar; if it's registered, it's important to refrain from contacting for sales and marketing purposes.
After changes localhost:3000 working as expected
![Screenshot 2024-06-11 at 12 14 02](https://github.com/Financial-Times/tps-lookup/assets/32463353/a6077800-cbac-4021-9ecf-dd45ee59e9ce)
Snyk test result:
![Screenshot 2024-06-11 at 12 07 42](https://github.com/Financial-Times/tps-lookup/assets/32463353/1a60acb0-0949-4419-9542-44a79b91b2ad)

