### PR TITLE
chore: removes semver package as not in use by the app

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,6 @@
         "express": "^4.19.2 ",
         "form-data": "^2.5.1",
         "sass": "^1.49.9",
-        "semver": "^6.3.1",
         "ssh2": "^1.0.0"
       },
       "devDependencies": {
@@ -10056,6 +10055,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "compileAll": "./bin/main.sh compileAll",
     "postinstall": "npm run compileAll",
     "start": "node app.js",
-    "start:dev": "doppler run -p ft-tps-screener -c dev -- node app.js"
+    "start:dev": "doppler run -p ft-tps-screener -c prod -- node app.js"
   },
   "author": "Andrew Snead",
   "license": "ISC",
@@ -29,7 +29,6 @@
     "express": "^4.19.2 ",
     "form-data": "^2.5.1",
     "sass": "^1.49.9",
-    "semver": "^6.3.1",
     "ssh2": "^1.0.0"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "compileAll": "./bin/main.sh compileAll",
     "postinstall": "npm run compileAll",
     "start": "node app.js",
-    "start:dev": "doppler run -p ft-tps-screener -c prod -- node app.js"
+    "start:dev": "doppler run -p ft-tps-screener -c dev -- node app.js"
   },
   "author": "Andrew Snead",
   "license": "ISC",


### PR DESCRIPTION
## Why?

As part of [JIRA4096 ](https://financialtimes.atlassian.net/browse/CRM-4096?atlOrigin=eyJpIjoiODA2Yzk1NzQ1MjJlNGRkOWE5ZGM0ZTkwNGQ5MjhiNjYiLCJwIjoiaiJ9) this PR is one of several separate PRs to remove deprecated npm packages or packages not in use by the app.

This PR removes `semver` package as it is not in use by the app

## What has changed? 

- `semver` is used for semantic versioning but it isn't use in this app (spot checked some other repos and it's not used in them)
- this PR removes the `semver` package

## Testing

- the app successfully ran when this package was uninstalled

## Note

- this PR branches off `master` so some packages in this app, such as `secret-squirrel` and `husky` are present here but are removed in other PRs and will be resolved in future merges
