### PR TITLE
Fix: Forgot to update the node version in CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 executors:
   node-executor:
     docker:
-      - image: cimg/node:18.16.1
+      - image: cimg/node:20.19.0
 commands:
   deploy-to-heroku:
     parameters:


### PR DESCRIPTION
## Why? OR The Problem

Cyber Essentials view of the Problem Hub was still flagging the node version for this system as being outdated. This was because I forgot to update the node version in the CircleCI config. 

## What has changed? OR The Solution

I have updated CircleCI config file. 

## Screenshots

All seems to be working when I test this (deploying my branch).

UI
![Screenshot 2025-05-15 at 11 28 35](https://github.com/user-attachments/assets/0341c88f-57c7-4305-9941-670cc79f55eb)
API
<img width="1030" alt="Screenshot 2025-05-15 at 11 29 02" src="https://github.com/user-attachments/assets/3c6b7764-737e-46d8-bb0d-803ca916b529" />

