### PR TITLE
Chore/migrate to aws

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,82 +1,67 @@
 version: 2.1
 orbs:
-  node: circleci/node@3.0.0
   change-api: financial-times/change-api@1
-executors:
-  node-executor:
-    docker:
-      - image: cimg/node:20.19.0
-commands:
-  deploy-to-heroku:
-    parameters:
-      app-name:
-        type: string
-    steps:
-      - run:
-          name: Git push to a heroku app
-          command: |
-            REMOTE=git.heroku.com/<<parameters.app-name>>.git
-            git push https://heroku:$HEROKU_API_KEY@$REMOTE master
+  hako: ft-circleci-orbs/hako@1.0
+  cloudsmith-docker: ft-circleci-orbs/cloudsmith-docker@0.0.4
+
 jobs:
-  build:
-    executor: node-executor
-    working_directory: ~/repo
+  build_tag_and_push_image:
+    docker:
+      - image: cimg/node:22.14.0
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - v1-dependencies-{{ checksum "package.json" }}
-            - v1-dependencies-
-
-      - run: npm install
-      - save_cache:
-          paths:
-            - node_modules
-          key: v1-dependencies-{{ checksum "package.json" }}
-
-  test:
-      executor: node-executor
-      working_directory: ~/repo
-      steps:
-        - checkout
-        - restore_cache:
-            keys:
-              - v1-dependencies-{{ checksum "package.json" }}
-              - v1-dependencies-
-        - run:
-            name: Run Jest Tests
-            command: npm test
-
-  deploy:
-    executor: node-executor
-    steps:
-      - checkout
-      - deploy-to-heroku:
-          app-name: ft-tps-screener
-
+      - run: echo "A first hello"
+      - run: npm install --no-save
+      - run: npm run test -- --runInBand
+      - setup_remote_docker
+      - cloudsmith-docker/build_image:
+          image_name: ft-tps-screener
+          image_registry: docker.packages.ft.com/ip-container-registry
+      - cloudsmith-docker/push_image:
+          image_name: ft-tps-screener
+          image_registry: docker.packages.ft.com/ip-container-registry
 workflows:
-  deploy:
+  version: 2.1
+  build_and_deploy_review:
     jobs:
-      - build
-      - test:
+      - build_tag_and_push_image:
+          filters:
+            branches:
+              ignore:
+                - master
+      - hako/deploy_image:
           requires:
-            - build
-      - deploy:
-          requires:
-            - test
-          context: ip-shared-creds
+            - build_tag_and_push_image
+          name: Deploy to AWS (Review EU)
+          image_tag: git-$(git rev-parse --short=8 HEAD)
+          image_name: ${CIRCLE_PROJECT_REPONAME}
+          aws_account_id: $AWS_ACCOUNT_ID
+          aws_region: eu-west-1
+          context: circleci-oidc-empty-context
+          hako_app: ${CIRCLE_PROJECT_REPONAME}
+          hako_env: crm-review-eu-west-1
+  build_and_deploy_prod:
+    jobs:
+      - build_tag_and_push_image:
           filters:
             branches:
               only:
                 - master
+      - hako/deploy_image:
+          requires:
+            - build_tag_and_push_image
+          name: Deploy to AWS (Prod EU)
+          image_tag: "git-${CIRCLE_SHA1:0:8}"
+          image_name: ${CIRCLE_PROJECT_REPONAME}
+          aws_account_id: $AWS_ACCOUNT_ID
+          aws_region: eu-west-1
+          context: circleci-oidc-empty-context
+          hako_app: ${CIRCLE_PROJECT_REPONAME}
+          hako_env: crm-prod-eu-west-1
       - change-api/change-log:
           requires:
-            - deploy
+            - Deploy to AWS (Prod EU)
           context: change-api-orb
-          system-code: "ft-tps-screener"
-          environment: "prod"
-          slack-channels: "crme-alerts"
-          filters:
-            branches:
-              only:
-                - master
+          system-code: ft-tps-screener
+          environment: prod
+          slack-channels: crme-alerts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,11 +34,11 @@ workflows:
             - build_tag_and_push_image
           name: Deploy to AWS (Review EU)
           image_tag: git-$(git rev-parse --short=8 HEAD)
-          image_name: ${CIRCLE_PROJECT_REPONAME}
+          image_name: ft-tps-screener
           aws_account_id: $AWS_ACCOUNT_ID
           aws_region: eu-west-1
           context: circleci-oidc-empty-context
-          hako_app: ${CIRCLE_PROJECT_REPONAME}
+          hako_app: ft-tps-screener
           hako_env: crm-review-eu-west-1
   build_and_deploy_prod:
     jobs:
@@ -52,11 +52,11 @@ workflows:
             - build_tag_and_push_image
           name: Deploy to AWS (Prod EU)
           image_tag: "git-${CIRCLE_SHA1:0:8}"
-          image_name: ${CIRCLE_PROJECT_REPONAME}
+          image_name: ft-tps-screener
           aws_account_id: $AWS_ACCOUNT_ID
           aws_region: eu-west-1
           context: circleci-oidc-empty-context
-          hako_app: ${CIRCLE_PROJECT_REPONAME}
+          hako_app: ft-tps-screener
           hako_env: crm-prod-eu-west-1
       - change-api/change-log:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ workflows:
           requires:
             - build_tag_and_push_image
           name: Deploy to AWS (Prod EU)
-          image_tag: "git-${CIRCLE_SHA1:0:8}"
+          image_tag: git-$(git rev-parse --short=8 HEAD)
           image_name: ft-tps-screener
           aws_account_id: $AWS_ACCOUNT_ID
           aws_region: eu-west-1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,14 @@ orbs:
   cloudsmith-docker: ft-circleci-orbs/cloudsmith-docker@0.0.4
 
 jobs:
+  test:
+    docker:
+      - image: cimg/node:22.14.0
+    steps:
+      - checkout
+      - run: npm install --no-save
+      - run: npm run test -- --runInBand
+
   build_tag_and_push_image:
     docker:
       - image: cimg/node:22.14.0
@@ -12,7 +20,6 @@ jobs:
       - checkout
       - run: echo "A first hello"
       - run: npm install --no-save
-      - run: npm run test -- --runInBand
       - setup_remote_docker
       - cloudsmith-docker/build_image:
           image_name: ft-tps-screener
@@ -21,11 +28,13 @@ jobs:
           image_name: ft-tps-screener
           image_registry: docker.packages.ft.com/ip-container-registry
 workflows:
-  version: 2.1
   build_and_deploy_review:
     jobs:
+      - test
       - build_tag_and_push_image:
-          filters:
+          requires:
+            - test
+          filters:            
             branches:
               ignore:
                 - master
@@ -42,7 +51,10 @@ workflows:
           hako_env: crm-review-eu-west-1
   build_and_deploy_prod:
     jobs:
+      - test
       - build_tag_and_push_image:
+          requires:
+            - test
           filters:
             branches:
               only:

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,5 @@
 node_modules
 .dockerignore
-Dockerfile
 .env
 .gitignore
 .github/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+node_modules
+.dockerignore
+Dockerfile
+.env
+.gitignore
+.github/
+.circleci/
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# syntax=docker/dockerfile:1
+
+# Use an official Node.js runtime as a base image
+FROM node:22-alpine
+
+# Set environment variable
+ARG NODE_ENV=production
+ENV NODE_ENV=$NODE_ENV
+
+# Set the working directory inside the container
+WORKDIR /app
+
+# Ensure the node user owns the directory
+RUN chown -R node:node /app
+
+# Switch to the non-root node user
+USER node
+
+# Copy dependency files and install dependencies
+COPY --chown=node:node package*.json ./
+RUN npm ci --omit=dev --ignore-scripts && npm cache clean --force
+
+# Copy the rest of the app source code
+COPY --chown=node:node . .
+
+# Set the default command to run your ETL script
+CMD ["node", "app.js"]

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: npm start

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Subsequently, an FT service can leverage the TPS Screener to intelligently refin
 
 ### Setting up/App run
 
-- Node ^20.x.x
+- Node ^22.x.x
 - [Doppler CLI](https://docs.doppler.com/docs/install-cli) if new to Doppler click to install the CLI.
 
 ### Run the app locally

--- a/hako-config/apps/ft-tps-screener/crm-prod-eu-west-1/app.yaml
+++ b/hako-config/apps/ft-tps-screener/crm-prod-eu-west-1/app.yaml
@@ -1,5 +1,5 @@
 application: ft-tps-screener #System code of the app
-environment: crm-review-eu-west-1  # This should already exist under environments of the ip-crm-hako-config repo
+environment: crm-prod-eu-west-1  # This should already exist under environments of the ip-crm-hako-config repo
 
 stacks:
   web:
@@ -12,7 +12,7 @@ stacks:
       ContainerRegistry: docker.packages.ft.com/ip-container-registry
       ContainerRegistryCredentialsSecretName: /hako/registry-credential/cloudsmith/crm-en-full-stack-read-only
       ContainerGoodToGoEndpoint: /__gtg
-      LogDestination: splunk 
+      # LogDestination: splunk 
       TaskPolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -44,9 +44,9 @@ stacks:
       ContainerRegistryCredentialsSecretName: /hako/registry-credential/cloudsmith/crm-en-full-stack-read-only
       TaskCpu: 256
       TaskMemory: 512
-      TaskSchedule: "daily at 14:38"
+      TaskSchedule: "daily at 20:08"
       ContainerCommand: npm run update
-      LogDestination: splunk
+      # LogDestination: splunk
 
   circleci-deployment-role:
     type: circleci-deployment-role
@@ -57,4 +57,4 @@ stacks:
 
 tags:
   systemCode: ft-tps-screener
-  environment: d
+  environment: p

--- a/hako-config/apps/ft-tps-screener/crm-prod-eu-west-1/app.yaml
+++ b/hako-config/apps/ft-tps-screener/crm-prod-eu-west-1/app.yaml
@@ -45,7 +45,7 @@ stacks:
       ContainerRegistryCredentialsSecretName: /hako/registry-credential/cloudsmith/crm-en-full-stack-read-only
       TaskCpu: 256
       TaskMemory: 512
-      TaskSchedule: "daily at 20:08"
+      TaskSchedule: "daily at 11:15"
       ContainerCommand: npm run update
       LogDestination: splunk
 

--- a/hako-config/apps/ft-tps-screener/crm-prod-eu-west-1/app.yaml
+++ b/hako-config/apps/ft-tps-screener/crm-prod-eu-west-1/app.yaml
@@ -12,7 +12,7 @@ stacks:
       ContainerRegistry: docker.packages.ft.com/ip-container-registry
       ContainerRegistryCredentialsSecretName: /hako/registry-credential/cloudsmith/crm-en-full-stack-read-only
       ContainerGoodToGoEndpoint: /__gtg
-      # LogDestination: splunk 
+      LogDestination: splunk 
       TaskPolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -22,6 +22,7 @@ stacks:
               - "dynamodb:GetItem"
               - "dynamodb:PutItem"
               - "dynamodb:UpdateItem"
+              - "dynamodb:DeleteItem"
               - "dynamodb:Query"
               - "dynamodb:Scan"
             Resource:
@@ -46,7 +47,7 @@ stacks:
       TaskMemory: 512
       TaskSchedule: "daily at 20:08"
       ContainerCommand: npm run update
-      # LogDestination: splunk
+      LogDestination: splunk
 
   circleci-deployment-role:
     type: circleci-deployment-role

--- a/hako-config/apps/ft-tps-screener/crm-review-eu-west-1/app.yaml
+++ b/hako-config/apps/ft-tps-screener/crm-review-eu-west-1/app.yaml
@@ -24,6 +24,8 @@ stacks:
               - "dynamodb:UpdateItem"
               - "dynamodb:Query"
               - "dynamodb:Scan"
+              - "dynamodb:ListTables"
+              - "dynamodb:DeleteItem"
             Resource:
               - arn:aws:dynamodb:eu-west-1:027104099916:table/ft-email_platform_tps_lookup*
           - Sid: "AccessS3Buckets"
@@ -44,7 +46,7 @@ stacks:
       ContainerRegistryCredentialsSecretName: /hako/registry-credential/cloudsmith/crm-en-full-stack-read-only
       TaskCpu: 256
       TaskMemory: 512
-      TaskSchedule: "daily at 14:59"
+      TaskSchedule: "daily at 15:09"
       ContainerCommand: npm run update
       LogDestination: splunk
 

--- a/hako-config/apps/ft-tps-screener/crm-review-eu-west-1/app.yaml
+++ b/hako-config/apps/ft-tps-screener/crm-review-eu-west-1/app.yaml
@@ -34,7 +34,7 @@ stacks:
               - "s3:ListBucket"
             Resource:
               - arn:aws:s3:::email-platform-ftcom-tps 
-              - arn:aws:s3:::email-platform-ftcom-tps /*
+              - arn:aws:s3:::email-platform-ftcom-tps/*
 
   scheduled-task:
     type: scheduled-task
@@ -44,8 +44,8 @@ stacks:
       ContainerRegistryCredentialsSecretName: /hako/registry-credential/cloudsmith/crm-en-full-stack-read-only
       TaskCpu: 256
       TaskMemory: 512
-      TaskSchedule: "daily at 17:35"
-      ContainerCommand: npm run update-numbers
+      TaskSchedule: "daily at 19:45"
+      ContainerCommand: npm run updateNumbers.js
       LogDestination: splunk
 
   circleci-deployment-role:

--- a/hako-config/apps/ft-tps-screener/crm-review-eu-west-1/app.yaml
+++ b/hako-config/apps/ft-tps-screener/crm-review-eu-west-1/app.yaml
@@ -26,6 +26,7 @@ stacks:
               - "dynamodb:Scan"
               - "dynamodb:ListTables"
               - "dynamodb:DeleteItem"
+              - "dynamodb:Scan"
             Resource:
               - arn:aws:dynamodb:eu-west-1:027104099916:table/ft-email_platform_tps_lookup*
           - Sid: "AccessS3Buckets"
@@ -46,7 +47,7 @@ stacks:
       ContainerRegistryCredentialsSecretName: /hako/registry-credential/cloudsmith/crm-en-full-stack-read-only
       TaskCpu: 256
       TaskMemory: 512
-      TaskSchedule: "daily at 16:22"
+      TaskSchedule: "daily at 17:57"
       ContainerCommand: npm run update
       LogDestination: splunk
 

--- a/hako-config/apps/ft-tps-screener/crm-review-eu-west-1/app.yaml
+++ b/hako-config/apps/ft-tps-screener/crm-review-eu-west-1/app.yaml
@@ -44,7 +44,7 @@ stacks:
       ContainerRegistryCredentialsSecretName: /hako/registry-credential/cloudsmith/crm-en-full-stack-read-only
       TaskCpu: 256
       TaskMemory: 512
-      TaskSchedule: "daily at 09:18"
+      TaskSchedule: "daily at 11:18"
       ContainerCommand: npm run update
       LogDestination: splunk
 

--- a/hako-config/apps/ft-tps-screener/crm-review-eu-west-1/app.yaml
+++ b/hako-config/apps/ft-tps-screener/crm-review-eu-west-1/app.yaml
@@ -44,7 +44,7 @@ stacks:
       ContainerRegistryCredentialsSecretName: /hako/registry-credential/cloudsmith/crm-en-full-stack-read-only
       TaskCpu: 256
       TaskMemory: 512
-      TaskSchedule: "daily at 14:38"
+      TaskSchedule: "daily at 14:59"
       ContainerCommand: npm run update
       LogDestination: splunk
 

--- a/hako-config/apps/ft-tps-screener/crm-review-eu-west-1/app.yaml
+++ b/hako-config/apps/ft-tps-screener/crm-review-eu-west-1/app.yaml
@@ -36,11 +36,24 @@ stacks:
               - arn:aws:s3:::email-platform-ftcom-tps 
               - arn:aws:s3:::email-platform-ftcom-tps /*
 
+  scheduled-task:
+    type: scheduled-task
+    parameters:
+      TaskCpuArchitecture: ARM64
+      ContainerRegistry: docker.packages.ft.com/ip-container-registry
+      ContainerRegistryCredentialsSecretName: /hako/registry-credential/cloudsmith/crm-en-full-stack-read-only
+      TaskCpu: 256
+      TaskMemory: 512
+      TaskSchedule: "daily at 15:25"
+      ContainerCommand: npm run update-numbers
+      LogDestination: splunk
+
   circleci-deployment-role:
     type: circleci-deployment-role
     parameters:
       CircleciProjectId: c9d89113-1fb3-43c5-869c-ad0b8eacf9d2 
       CircleciOrgName: Financial-Times
+
 
 tags:
   systemCode: ft-tps-screener

--- a/hako-config/apps/ft-tps-screener/crm-review-eu-west-1/app.yaml
+++ b/hako-config/apps/ft-tps-screener/crm-review-eu-west-1/app.yaml
@@ -26,7 +26,6 @@ stacks:
               - "dynamodb:Scan"
               - "dynamodb:ListTables"
               - "dynamodb:DeleteItem"
-              - "dynamodb:Scan"
             Resource:
               - arn:aws:dynamodb:eu-west-1:027104099916:table/ft-email_platform_tps_lookup*
           - Sid: "AccessS3Buckets"

--- a/hako-config/apps/ft-tps-screener/crm-review-eu-west-1/app.yaml
+++ b/hako-config/apps/ft-tps-screener/crm-review-eu-west-1/app.yaml
@@ -44,7 +44,7 @@ stacks:
       ContainerRegistryCredentialsSecretName: /hako/registry-credential/cloudsmith/crm-en-full-stack-read-only
       TaskCpu: 256
       TaskMemory: 512
-      TaskSchedule: "daily at 20:08"
+      TaskSchedule: "daily at 09:18"
       ContainerCommand: npm run update
       LogDestination: splunk
 

--- a/hako-config/apps/ft-tps-screener/crm-review-eu-west-1/app.yaml
+++ b/hako-config/apps/ft-tps-screener/crm-review-eu-west-1/app.yaml
@@ -44,7 +44,7 @@ stacks:
       ContainerRegistryCredentialsSecretName: /hako/registry-credential/cloudsmith/crm-en-full-stack-read-only
       TaskCpu: 256
       TaskMemory: 512
-      TaskSchedule: "daily at 11:18"
+      TaskSchedule: "daily at 14:18"
       ContainerCommand: npm run update
       LogDestination: splunk
 

--- a/hako-config/apps/ft-tps-screener/crm-review-eu-west-1/app.yaml
+++ b/hako-config/apps/ft-tps-screener/crm-review-eu-west-1/app.yaml
@@ -46,7 +46,7 @@ stacks:
       ContainerRegistryCredentialsSecretName: /hako/registry-credential/cloudsmith/crm-en-full-stack-read-only
       TaskCpu: 256
       TaskMemory: 512
-      TaskSchedule: "daily at 15:09"
+      TaskSchedule: "daily at 16:22"
       ContainerCommand: npm run update
       LogDestination: splunk
 

--- a/hako-config/apps/ft-tps-screener/crm-review-eu-west-1/app.yaml
+++ b/hako-config/apps/ft-tps-screener/crm-review-eu-west-1/app.yaml
@@ -44,7 +44,7 @@ stacks:
       ContainerRegistryCredentialsSecretName: /hako/registry-credential/cloudsmith/crm-en-full-stack-read-only
       TaskCpu: 256
       TaskMemory: 512
-      TaskSchedule: "daily at 15:25"
+      TaskSchedule: "daily at 17:35"
       ContainerCommand: npm run update-numbers
       LogDestination: splunk
 

--- a/hako-config/apps/ft-tps-screener/crm-review-eu-west-1/app.yaml
+++ b/hako-config/apps/ft-tps-screener/crm-review-eu-west-1/app.yaml
@@ -44,8 +44,8 @@ stacks:
       ContainerRegistryCredentialsSecretName: /hako/registry-credential/cloudsmith/crm-en-full-stack-read-only
       TaskCpu: 256
       TaskMemory: 512
-      TaskSchedule: "daily at 19:45"
-      ContainerCommand: npm run updateNumbers.js
+      TaskSchedule: "daily at 19:58"
+      ContainerCommand: npm run update
       LogDestination: splunk
 
   circleci-deployment-role:

--- a/hako-config/apps/ft-tps-screener/crm-review-eu-west-1/app.yaml
+++ b/hako-config/apps/ft-tps-screener/crm-review-eu-west-1/app.yaml
@@ -44,7 +44,7 @@ stacks:
       ContainerRegistryCredentialsSecretName: /hako/registry-credential/cloudsmith/crm-en-full-stack-read-only
       TaskCpu: 256
       TaskMemory: 512
-      TaskSchedule: "daily at 19:58"
+      TaskSchedule: "daily at 20:08"
       ContainerCommand: npm run update
       LogDestination: splunk
 

--- a/hako-config/apps/ft-tps-screener/crm-review-eu-west-1/app.yaml
+++ b/hako-config/apps/ft-tps-screener/crm-review-eu-west-1/app.yaml
@@ -1,0 +1,47 @@
+application: ft-tps-screener #System code of the app
+environment: crm-review-eu-west-1  # This should already exist under environments of the ip-crm-hako-config repo
+
+stacks:
+  web:
+    type: public-load-balanced-web-service
+    parameters:
+      TaskCount: 1
+      TaskCpu: 256
+      TaskCpuArchitecture: ARM64
+      TaskMemory: 512
+      ContainerRegistry: docker.packages.ft.com/ip-container-registry
+      ContainerRegistryCredentialsSecretName: /hako/registry-credential/cloudsmith/crm-en-full-stack-read-only
+      ContainerGoodToGoEndpoint: /__gtg
+      LogDestination: splunk 
+      TaskPolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: "AccessDynamoDBTables"
+            Effect: "Allow"
+            Action:
+              - "dynamodb:GetItem"
+              - "dynamodb:PutItem"
+              - "dynamodb:UpdateItem"
+              - "dynamodb:Query"
+              - "dynamodb:Scan"
+            Resource:
+              - arn:aws:dynamodb:eu-west-1:027104099916:table/ft-email_platform_tps_lookup*
+          - Sid: "AccessS3Buckets"
+            Effect: "Allow"
+            Action:
+              - "s3:GetObject"
+              - "s3:PutObject"
+              - "s3:ListBucket"
+            Resource:
+              - arn:aws:s3:::email-platform-ftcom-tps 
+              - arn:aws:s3:::email-platform-ftcom-tps /*
+
+  circleci-deployment-role:
+    type: circleci-deployment-role
+    parameters:
+      CircleciProjectId: c9d89113-1fb3-43c5-869c-ad0b8eacf9d2 
+      CircleciOrgName: Financial-Times
+
+tags:
+  systemCode: ft-tps-screener
+  environment: d

--- a/package-lock.json
+++ b/package-lock.json
@@ -2149,15 +2149,6 @@
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ=="
     },
-    "node_modules/buildcheck": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.3.tgz",
-      "integrity": "sha512-pziaA+p/wdVImfcbsZLNF32EiWyujlQLwolMqUQE8xpKNOH7KmZQaY8sXN7DGOEzPAElo9QTaeNRfGnf3iOJbA==",
-      "optional": true,
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/builtin-status-codes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
@@ -2583,20 +2574,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
-    },
-    "node_modules/cpu-features": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.4.tgz",
-      "integrity": "sha512-fKiZ/zp1mUwQbnzb9IghXtHtDoTMtNeb8oYGx6kX2SYfhnG0HNdBEBIzB9b5KlXu5DQPhfy3mInbBxFcgwAr3A==",
-      "hasInstallScript": true,
-      "optional": true,
-      "dependencies": {
-        "buildcheck": "0.0.3",
-        "nan": "^2.15.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
     },
     "node_modules/create-ecdh": {
       "version": "4.0.4",
@@ -5281,12 +5258,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
-    },
-    "node_modules/nan": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
-      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==",
-      "optional": true
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "supertest": "^7.1.1"
       },
       "engines": {
-        "node": "20.x"
+        "node": "22.x"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "start:dev": "doppler run -p ft-tps-screener -c dev -- node app.js",
     "test": "jest",
     "test:watch": "jest --watch",
-    "test:coverage": "jest --coverage"
+    "test:coverage": "jest --coverage",
+    "update-numbers": "doppler run -p ft-tps-screener -c dev -- node updateNumbers.js"
   },
   "author": "Andrew Snead",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
-    "update-numbers": "doppler run -p ft-tps-screener -c dev -- node updateNumbers.js"
+    "update-numbers": "doppler run -p ft-tps-screener -c dev -- node updateNumbers.js",
+    "update": "node updateNumbers.js"
   },
   "author": "Andrew Snead",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "ssh2": "^1.0.0"
   },
   "engines": {
-    "node": "20.x"
+    "node": "22.x"
   },
   "overrides": {},
   "volta": {

--- a/updateNumbers.js
+++ b/updateNumbers.js
@@ -23,12 +23,11 @@ async function checkAwsAccess() {
     // S3: List first 1 object in the bucket
     const s3Result = await s3.listObjectsV2({ Bucket: "email-platform-ftcom-tps", MaxKeys: 1 }).promise();
     logger.info({ event: "S3 access check successful", objects: s3Result.Contents.length });
+    const result = await docClient.service.describeTable({ TableName: config.tableName }).promise();
+    logger.info({ event: "DynamoDB table access check successful", table: result.Table.TableName });
 
-    // DynamoDB: List tables as a simple check
-    const dynamoResult = await docClient.service.listTables({ Limit: 1 }).promise();
-    logger.info({ event: "DynamoDB access check successful", tables: dynamoResult.TableNames });
   } catch (err) {
-    logger.error({ event: "AWS access check failed", error: err.toString() });
+    logger.error({ event: "DynamoDB table access check failed", error: err.toString() });
     process.exit(1);
   }
 }

--- a/updateNumbers.js
+++ b/updateNumbers.js
@@ -32,8 +32,7 @@ async function checkAwsAccess() {
 }
 
 checkAwsAccess().then(() => {
-  logger.info({ event: "AWS access confirmed, continuing with main script..." });
-  // ...existing code continues here...
+  logger.info({ event: 'AWS access confirmed' });
 });
 
 let done = 0;

--- a/updateNumbers.js
+++ b/updateNumbers.js
@@ -20,7 +20,6 @@ const docClient = new AWS.DynamoDB.DocumentClient();
 
 async function checkAwsAccess() {
   try {
-    // S3: List first 1 object in the bucket
     const s3Result = await s3.listObjectsV2({ Bucket: "email-platform-ftcom-tps", MaxKeys: 1 }).promise();
     logger.info({ event: "S3 access check successful", objects: s3Result.Contents.length });
     const result = await docClient.service.describeTable({ TableName: config.tableName }).promise();
@@ -32,13 +31,11 @@ async function checkAwsAccess() {
   }
 }
 
-// Call the check before main logic
 checkAwsAccess().then(() => {
   logger.info({ event: "AWS access confirmed, continuing with main script..." });
   // ...existing code continues here...
 });
 
-// both files uploaded and complete === 2
 let done = 0;
 
 function uploadToS3(fileStream, key) {

--- a/updateNumbers.js
+++ b/updateNumbers.js
@@ -22,7 +22,7 @@ async function checkAwsAccess() {
   try {
     const s3Result = await s3.listObjectsV2({ Bucket: "email-platform-ftcom-tps", MaxKeys: 1 }).promise();
     logger.info({ event: "S3 access check successful", objects: s3Result.Contents.length });
-    const result = await docClient.service.describeTable({ TableName: config.tableName }).promise();
+    const result = await dynamoDB.describeTable({ TableName: config.tableName }).promise();
     logger.info({ event: "DynamoDB table access check successful", table: result.Table.TableName });
 
   } catch (err) {

--- a/updateNumbers.js
+++ b/updateNumbers.js
@@ -18,6 +18,27 @@ AWS.config.update({
 const s3 = new AWS.S3({});
 const docClient = new AWS.DynamoDB.DocumentClient();
 
+async function checkAwsAccess() {
+  try {
+    // S3: List first 1 object in the bucket
+    const s3Result = await s3.listObjectsV2({ Bucket: "email-platform-ftcom-tps", MaxKeys: 1 }).promise();
+    logger.info({ event: "S3 access check successful", objects: s3Result.Contents.length });
+
+    // DynamoDB: List tables as a simple check
+    const dynamoResult = await docClient.service.listTables({ Limit: 1 }).promise();
+    logger.info({ event: "DynamoDB access check successful", tables: dynamoResult.TableNames });
+  } catch (err) {
+    logger.error({ event: "AWS access check failed", error: err.toString() });
+    process.exit(1);
+  }
+}
+
+// Call the check before main logic
+checkAwsAccess().then(() => {
+  logger.info({ event: "AWS access confirmed, continuing with main script..." });
+  // ...existing code continues here...
+});
+
 // both files uploaded and complete === 2
 let done = 0;
 


### PR DESCRIPTION
## Migrate to AWS
- We're migrating the `tps-looker` AKA `tps-screener`  from Heroku to AWS (ECS)
- This PR enables ECS deployment to the production environment.

JIRA: [CRM-7240](https://financialtimes.atlassian.net/browse/CRM-7240)

## What has changed? OR The Solution
- Added app.yaml config for the ECS prod environment (ft-tps-screener in the crm-prod cluster)
- Added app.yaml config for the ECS review environment (ft-tps-screener in the crm-review cluster)
- Updated CircleCI to deploy branches other than main to review in ECS and master branch merges to prod in ECS
- confirmed ECS role has access to S3 and DynamoDB 
- PR to split the traffic between ECS and Heroku (just for migration day) is [here](https://github.com/Financial-Times/dns/pull/4644). 

## Highlight to reviewers
- Go live steps are [here](https://financialtimes.atlassian.net/wiki/spaces/SF/pages/9102327811/ft-tps-screener+AWS+migration+go-live+comms+and+checklist#:~:text=before%20go%2Dlive.-,Go%2DLive%20Checklist,-Confirm%20latest%20version)
- A scheduled task updates numbers by accessing the tps SFTP site - however we have been getting an [error ](https://financialtimes.splunkcloud.com/en-GB/app/search/search?earliest=-1q&latest=now&q=search%20index%3Dheroku%20source%3D%22ft-tps-screener%22%20host%3D%22ft-tps-screener.herokuapp.com%22%20ftp.ctpsonline.org.uk&display.page.search.mode=verbose&dispatch.sample_ratio=1&workload_pool=&sid=1749638755.34601) since 11 April 2025 - will tackle this separately in [CRM-7512](https://financialtimes.atlassian.net/browse/CRM-7512).
- README will be updated as part of the decomm work

[CRM-7240]: https://financialtimes.atlassian.net/browse/CRM-7240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CRM-7512]: https://financialtimes.atlassian.net/browse/CRM-7512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ