### PR TITLE
docs: change to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ scheduled-task:
  ```
 ⚠️ Times are always in UTC — so adjust accordingly for UK time (e.g. 23:00 UTC = midnight BST).
 
-How to change the schedule
+How to change the schedule:
 1. Pull the repo and open:
 `hako-config/apps/ft-tps-screener/crm-prod-eu-west-1/app.yaml`
 


### PR DESCRIPTION
## Why? OR The Problem

Recent changes to how this app syncs its secrets from Doppler to AWS Secrets Store has required us to remove the app and redeploy it. The Hako configuration has been completed but the docker image needs to be deployed to AWS via CircleCI

## What has changed? OR The Solution

In order to initiate a deploy via CircleCI to enable the app to be deployed to ECS a small change to the readme file has been done.

